### PR TITLE
Replace loop variable in range with specific one

### DIFF
--- a/internal/pd/list-on-calls.go
+++ b/internal/pd/list-on-calls.go
@@ -65,7 +65,9 @@ func GetPagerDutyOnCalls(client *pagerduty.Client) (map[TimeRange]map[string]pag
 	}
 
 	var oncalls = map[TimeRange]map[string]pagerduty.EscalationPolicy{}
-	for _, oncall := range list.OnCalls {
+	for i := range list.OnCalls {
+		oncall := list.OnCalls[i]
+
 		start, err := parsePagerDutyTime(oncall.Start)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
To avoid using wrong references, the for loop implicit variable can cause
inconsistencies since it is reused for multiple loops.

Replace implicit loop variable with explicit one.