### PR TITLE
Add new command shift-report

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,7 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/gonvenience/bunt v1.1.1/go.mod h1:lsyhkmNpSAzhVx059BD0fQy5F29rWcS6AHb7UWNlT/s=
 github.com/gonvenience/bunt v1.1.3 h1:jGqAxYR+4JDicbA8qivc3zMK1aeo1D7P3F3wYM1M32I=
 github.com/gonvenience/bunt v1.1.3/go.mod h1:hZ898ZprNWgaVlq4s1ivsJu3AY+3wrlJadF5Gp7Yq2c=
+github.com/gonvenience/bunt v1.1.4 h1:JQopjIzeXvFjWiVp9ku8hqEZfm466Pzqp7nAxwNMreg=
 github.com/gonvenience/bunt v1.1.4/go.mod h1:hZ898ZprNWgaVlq4s1ivsJu3AY+3wrlJadF5Gp7Yq2c=
 github.com/gonvenience/neat v1.3.0 h1:DKlFjUuEOoJaYEBejxRhim3T804kXW5ppj/r0+2VvaE=
 github.com/gonvenience/neat v1.3.0/go.mod h1:8b38eXyZUqm0e+q6wP/ueDNXM8Frn0Tr2Pd9GQo9FOA=

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -1,0 +1,149 @@
+// Copyright © 2020 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/gonvenience/wrap"
+	"github.com/homeport/pd/internal/pd"
+)
+
+func getRelevantIncidents(userID string, from string, to string) ([]pagerduty.Incident, string, error) {
+	client, err := pd.CreatePagerDutyClient()
+	if err != nil {
+		return nil, "", err
+	}
+
+	var user *pagerduty.User
+	if userID == "" {
+		user, err = client.GetCurrentUser(pagerduty.GetCurrentUserOptions{})
+		if err != nil {
+			return nil, user.Name, wrap.Error(err, "it seems like the authtoken is not set correctly or outdated. Please update the authtoken in the .pd.yml file. If you don't know how to create your authtoken, this might help:\n https://support.pagerduty.com/docs/generating-api-keys#generating-a-personal-rest-api-key\n")
+		}
+	} else {
+		user, err = client.GetUser(userID, pagerduty.GetUserOptions{})
+		if err != nil {
+			return nil, user.Name, wrap.Error(err, "it seems like the authtoken is not set correctly/outdated or the user-ID is invalid. Please update the authtoken in the .pd.yml file or use another user-ID. If you don't know how to create your authtoken, this might help:\n https://support.pagerduty.com/docs/generating-api-keys#generating-a-personal-rest-api-key\n")
+		}
+	}
+
+	incidents := []pagerduty.Incident{}
+	offset := 0
+	limit := 100
+	teamIDs := listTeamIDs(*user)
+	moreIncidents := len(teamIDs) > 0
+	if !moreIncidents {
+		return nil, user.Name, errors.New("this PagerDuty-account is not part of any teams. To use this function, the PagerDuty-account must be part of at least one team")
+	}
+	for moreIncidents {
+		listIncidentsOptions := pagerduty.ListIncidentsOptions{
+			APIListObject: pagerduty.APIListObject{
+				Limit:  uint(limit),
+				Offset: uint(offset),
+			},
+			Since:   from,
+			Until:   to,
+			TeamIDs: teamIDs,
+		}
+		a, err := client.ListIncidents(listIncidentsOptions)
+		if err != nil {
+			return incidents, user.Name, err
+		}
+		incs, err := filterIncidentsByNameInLogEntries(a.Incidents, user.Name, client)
+		if err != nil {
+			return incidents, user.Name, err
+		}
+		incidents = append(incidents, incs...)
+
+		if a.More {
+			offset += limit
+		} else {
+			moreIncidents = false
+		}
+	}
+
+	return incidents, user.Name, nil
+}
+
+func filterIncidentsByNameInLogEntries(incidents []pagerduty.Incident, username string, client *pagerduty.Client) ([]pagerduty.Incident, error) {
+	const parallel = 10
+
+	type in struct {
+		index    int
+		incident pagerduty.Incident
+	}
+
+	var (
+		errors     = []error{}
+		tasks      = make(chan in, len(incidents))
+		logEntries = make([]pagerduty.ListIncidentLogEntriesResponse, len(incidents))
+	)
+
+	// Fill the task channel with work to be done
+	for idx, incident := range incidents {
+		tasks <- in{idx, incident}
+	}
+
+	// Start a worker group to process work tasks
+	var wg sync.WaitGroup
+	wg.Add(parallel)
+	for i := 0; i < parallel; i++ {
+		go func() {
+			defer wg.Done()
+			for task := range tasks {
+				resp, err := client.ListIncidentLogEntries(task.incident.Id, pagerduty.ListIncidentLogEntriesOptions{})
+				if err != nil {
+					errors = append(errors, err)
+				}
+				logEntries[task.index] = *resp
+			}
+		}()
+	}
+	close(tasks)
+	wg.Wait()
+
+	var filteredIncidents []pagerduty.Incident
+	for i, incident := range incidents {
+		for _, logEntry := range logEntries[i].LogEntries {
+			if strings.Contains(logEntry.CommonLogEntryField.Summary, username) {
+				filteredIncidents = append(filteredIncidents, incident)
+				break
+			}
+		}
+	}
+	if len(errors) > 0 {
+		return filteredIncidents, wrap.Errors(errors, "failed to filter incidents by name")
+	}
+	return filteredIncidents, nil
+
+}
+
+func listTeamIDs(user pagerduty.User) []string {
+	result := make([]string, len(user.Teams))
+	for i, team := range user.Teams {
+		result[i] = team.ID
+	}
+	return result
+}

--- a/internal/cmd/shift-report.go
+++ b/internal/cmd/shift-report.go
@@ -1,0 +1,137 @@
+// Copyright © 2020 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"html/template"
+	"os"
+	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/gonvenience/bunt"
+	"github.com/homeport/pd/internal/pd"
+	"github.com/spf13/cobra"
+)
+
+type relevantIncidentsReturn struct {
+	Title             string
+	RelevantIncidents []pagerduty.Incident
+	OtherIncidents    []pagerduty.Incident
+}
+
+var shiftReportCmdSettings struct {
+	id           string
+	templateName string
+	date         string
+}
+
+// onCallCmd represents the onCall command
+var shiftReportCmd = &cobra.Command{
+	Use:   "shift-report",
+	Args:  cobra.MaximumNArgs(1),
+	Short: "Creates shift report",
+	Long:  `Creates a shift report based on the provided template`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if shiftReportCmdSettings.id == "" || shiftReportCmdSettings.templateName == "" || shiftReportCmdSettings.date == "" {
+			bunt.Println("\nPlease use all flags!\n")
+			return nil
+		}
+
+		incidents, username, err := getRelevantIncidents(shiftReportCmdSettings.id, shiftReportCmdSettings.date+"T00:00:01Z", shiftReportCmdSettings.date+"T23:59:59Z")
+		if err != nil {
+			return err
+		}
+
+		data, err := pd.GetTemplate(shiftReportCmdSettings.templateName)
+		if err != nil {
+			return err
+		}
+
+		shifts, _, shiftPos, err := pd.GetCurrentAndOwnShift()
+		if err != nil {
+			return err
+		}
+
+		funcMap := map[string]interface{}{
+			"makeSlice":                    makeSlice,
+			"getCategoryMatchingIncidents": getCategoryMatchingIncidents,
+		}
+		temp := template.New("template").Funcs(template.FuncMap(funcMap))
+
+		temp, _ = temp.Parse(string(data))
+
+		input := struct {
+			Username        string
+			Date            string
+			StartOfOwnShift string
+			EndOfOwnShift   string
+			Incidents       []pagerduty.Incident
+		}{
+			Username:        username,
+			Date:            shiftReportCmdSettings.date,
+			StartOfOwnShift: convertTimeIntToString(int(shifts[shiftPos].Start)),
+			EndOfOwnShift:   convertTimeIntToString(int(shifts[shiftPos].End)),
+			Incidents:       incidents,
+		}
+
+		bunt.Println()
+		temp.Execute(os.Stdout, input)
+
+		return nil
+	},
+}
+
+func convertTimeIntToString(i int) string {
+	return bunt.Sprintf("%02d:%02d", i/60, i%60)
+}
+
+func makeSlice(args ...interface{}) []interface{} {
+	return args
+}
+
+func getCategoryMatchingIncidents(name string, incidents []pagerduty.Incident) relevantIncidentsReturn {
+	posSeparator := strings.Index(name, "--")
+	if posSeparator == -1 {
+		return relevantIncidentsReturn{Title: name, RelevantIncidents: incidents, OtherIncidents: []pagerduty.Incident{}}
+	}
+	searchFor := name[posSeparator+2:]
+	name = name[:posSeparator]
+	relevantIncidents := []pagerduty.Incident{}
+	otherIncidents := []pagerduty.Incident{}
+	for _, incident := range incidents {
+		if strings.Contains(incident.Title, searchFor) {
+			relevantIncidents = append(relevantIncidents, incident)
+		} else {
+			otherIncidents = append(otherIncidents, incident)
+		}
+	}
+	incidents = otherIncidents
+	return relevantIncidentsReturn{Title: name, RelevantIncidents: relevantIncidents, OtherIncidents: otherIncidents}
+}
+
+func init() {
+	rootCmd.AddCommand(shiftReportCmd)
+
+	shiftReportCmd.Flags().StringVar(&shiftReportCmdSettings.id, "id", "", "use custom ID")
+	shiftReportCmd.Flags().StringVar(&shiftReportCmdSettings.templateName, "template", "", "set path of shift-report.template file")
+	shiftReportCmd.Flags().StringVar(&shiftReportCmdSettings.date, "date", "", "set date of shift report")
+}

--- a/internal/pd/list-on-calls.go
+++ b/internal/pd/list-on-calls.go
@@ -97,6 +97,15 @@ func GetAllOnCalls(client *pagerduty.Client, user *pagerduty.User, start string,
 	return client.ListOnCalls(listOptions)
 }
 
+// GetTemplate returns the requested template
+func GetTemplate(templateName string) (string, error) {
+	config, err := loadConfig()
+	if err != nil {
+		return "", err
+	}
+	return config.Templates[templateName], err
+}
+
 func loadConfig() (*Config, error) {
 
 	data, err := getDataFromYAMLFile()

--- a/internal/pd/models.go
+++ b/internal/pd/models.go
@@ -40,6 +40,8 @@ type Config struct {
 		Start string `yaml:"start"`
 		End   string `yaml:"end"`
 	} `yaml:"shift-times"`
+
+	Templates map[string]string `yaml:"templates"`
 }
 
 // ChangeYAMLFile changes a specific value in the .pd.yml file


### PR DESCRIPTION
A user does not want to create a unique shift report after every shift.

Add file for duplicate code in different commands.

Refactor list-alerts command to use standardised methods.

Change structure of .pd.yml file to include templates.